### PR TITLE
Update substrate commit for the `darwinia-v0.12.4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4401f0a3622dad2e0763fa79e0eb328bc70fb7dccfdd645341f00d671247d6"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-sink",
  "futures-util",
  "memchr",
@@ -335,7 +335,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-sink",
  "futures-util",
  "memchr",
@@ -413,12 +413,6 @@ checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -431,6 +425,12 @@ checksum = "bed554bd50246729a1ec158d08aa3235d1b69d94ad120ebe187e28894787e736"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bimap"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0455254eb5c6964c4545d8bac815e1a1be4f3afe0ae695ea539c12d728d44b"
 
 [[package]]
 name = "bitflags"
@@ -904,12 +904,6 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
@@ -1318,6 +1312,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
 name = "dyn-clonable"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1519,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.2.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1545,7 +1545,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1563,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1595,7 +1595,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1610,6 +1610,7 @@ dependencies = [
  "smallvec",
  "sp-arithmetic",
  "sp-core",
+ "sp-core-hashing-proc-macro",
  "sp-inherents",
  "sp-io",
  "sp-runtime",
@@ -1617,12 +1618,13 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-tracing",
+ "tt-call",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -1634,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.1.0",
@@ -1646,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1656,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "frame-support",
  "log",
@@ -1985,7 +1987,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -1996,7 +1998,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "http",
  "pin-project-lite 0.2.7",
 ]
@@ -2034,7 +2036,7 @@ version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2365,7 +2367,7 @@ dependencies = [
  "jsonrpsee-types",
  "pin-project 1.0.8",
  "rustls-native-certs",
- "soketto 0.7.1",
+ "soketto",
  "thiserror",
  "tokio",
  "tokio-rustls",
@@ -2391,7 +2393,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "soketto 0.7.1",
+ "soketto",
  "thiserror",
  "tokio",
  "tracing",
@@ -2489,12 +2491,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9004c06878ef8f3b4b4067e69a140d87ed20bf777287f82223e49713b36ee433"
+checksum = "3bec54343492ba5940a6c555e512c6721139835d28c59bc22febece72dfd0d9d"
 dependencies = [
  "atomic",
- "bytes 1.1.0",
+ "bytes",
  "futures 0.3.18",
  "lazy_static",
  "libp2p-core",
@@ -2505,12 +2507,14 @@ dependencies = [
  "libp2p-identify",
  "libp2p-kad",
  "libp2p-mdns",
+ "libp2p-metrics",
  "libp2p-mplex",
  "libp2p-noise",
  "libp2p-ping",
  "libp2p-plaintext",
  "libp2p-pnet",
  "libp2p-relay",
+ "libp2p-rendezvous",
  "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-swarm-derive",
@@ -2528,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.29.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9b4abdeaa420593a297c8592f63fad4234f4b88dc9343b8fd8e736c35faa59"
+checksum = "86aad7d54df283db817becded03e611137698a6509d4237a96881976a162340c"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2539,8 +2543,9 @@ dependencies = [
  "fnv",
  "futures 0.3.18",
  "futures-timer",
+ "instant",
  "lazy_static",
- "libsecp256k1 0.5.0",
+ "libsecp256k1",
  "log",
  "multiaddr",
  "multihash 0.14.0",
@@ -2549,7 +2554,7 @@ dependencies = [
  "pin-project 1.0.8",
  "prost",
  "prost-build",
- "rand 0.7.3",
+ "rand 0.8.4",
  "ring",
  "rw-stream-sink",
  "sha2 0.9.8",
@@ -2562,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-deflate"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66097fccc0b7f8579f90a03ea76ba6196332ea049fd07fd969490a06819dcdc8"
+checksum = "51a800adb195f33de63f4b17b63fe64cfc23bf2c6a0d3d0d5321328664e65197"
 dependencies = [
  "flate2",
  "futures 0.3.18",
@@ -2573,9 +2578,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ff08b3196b85a17f202d80589e93b1660a574af67275706657fdc762e42c32"
+checksum = "bb8f89d15cb6e3c5bc22afff7513b11bab7856f2872d3cfba86f7f63a06bc498"
 dependencies = [
  "async-std-resolver",
  "futures 0.3.18",
@@ -2587,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404eca8720967179dac7a5b4275eb91f904a53859c69ca8d018560ad6beb214f"
+checksum = "aab3d7210901ea51b7bae2b581aa34521797af8c4ec738c980bda4a06434067f"
 dependencies = [
  "cuckoofilter",
  "fnv",
@@ -2605,14 +2610,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1cc48709bcbc3a3321f08a73560b4bbb4166a7d56f6fdb615bc775f4f91058e"
+checksum = "dfeead619eb5dac46e65acc78c535a60aaec803d1428cca6407c3a4fc74d698d"
 dependencies = [
  "asynchronous-codec 0.6.0",
- "base64 0.13.0",
+ "base64",
  "byteorder",
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "futures 0.3.18",
  "hex_fmt",
@@ -2631,14 +2636,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b61f6cf07664fb97016c318c4d4512b3dd4cc07238607f3f0163245f99008e"
+checksum = "cca1275574183f288ff8b72d535d5ffa5ea9292ef7829af8b47dcb197c7b0dcd"
 dependencies = [
  "futures 0.3.18",
  "libp2p-core",
  "libp2p-swarm",
  "log",
+ "lru 0.6.6",
  "prost",
  "prost-build",
  "smallvec",
@@ -2647,13 +2653,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ed78489c87924235665a0ab345b298ee34dff0f7ad62c0ba6608b2144fb75e"
+checksum = "a2297dc0ca285f3a09d1368bde02449e539b46f94d32d53233f53f6625bcd3ba"
 dependencies = [
  "arrayvec 0.5.2",
  "asynchronous-codec 0.6.0",
- "bytes 1.1.0",
+ "bytes",
  "either",
  "fnv",
  "futures 0.3.18",
@@ -2673,9 +2679,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29e6cbc2a24b8471b6567e580a0e8e7b70a6d0f0ea2be0844d1e842d7d4fa33"
+checksum = "14c864b64bdc8a84ff3910a0df88e6535f256191a450870f1e7e10cbf8e64d45"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -2693,13 +2699,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-mplex"
-version = "0.29.0"
+name = "libp2p-metrics"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313d9ea526c68df4425f580024e67a9d3ffd49f2c33de5154b1f5019816f7a99"
+checksum = "4af432fcdd2f8ba4579b846489f8f0812cfd738ced2c0af39df9b1c48bbb6ab2"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identify",
+ "libp2p-kad",
+ "libp2p-ping",
+ "libp2p-swarm",
+ "open-metrics-client",
+]
+
+[[package]]
+name = "libp2p-mplex"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2cd64ef597f40e14bfce0497f50ecb63dd6d201c61796daeb4227078834fbf"
 dependencies = [
  "asynchronous-codec 0.6.0",
- "bytes 1.1.0",
+ "bytes",
  "futures 0.3.18",
  "libp2p-core",
  "log",
@@ -2712,11 +2732,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1db7212f342b6ba7c981cc40e31f76e9e56cb48e65fa4c142ecaca5839523e"
+checksum = "a8772c7a99088221bb7ca9c5c0574bf55046a7ab4c319f3619b275f28c8fb87a"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "curve25519-dalek 3.2.0",
  "futures 0.3.18",
  "lazy_static",
@@ -2734,9 +2754,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2482cfd9eb0b7a0baaf3e7b329dc4f2785181a161b1a47b7192f8d758f54a439"
+checksum = "80ef7b0ec5cf06530d9eb6cf59ae49d46a2c45663bde31c25a12f682664adbcf"
 dependencies = [
  "futures 0.3.18",
  "libp2p-core",
@@ -2749,12 +2769,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b4783e5423870b9a5c199f65a7a3bc66d86ab56b2b9beebf3c338d889cf8e4"
+checksum = "5fba1a6ff33e4a274c89a3b1d78b9f34f32af13265cc5c46c16938262d4e945a"
 dependencies = [
  "asynchronous-codec 0.6.0",
- "bytes 1.1.0",
+ "bytes",
  "futures 0.3.18",
  "libp2p-core",
  "log",
@@ -2766,9 +2786,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-pnet"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cb4dd4b917e5b40ddefe49b96b07adcd8d342e0317011d175b7b2bb1dcc974"
+checksum = "0f1a458bbda880107b5b36fcb9b5a1ef0c329685da0e203ed692a8ebe64cc92c"
 dependencies = [
  "futures 0.3.18",
  "log",
@@ -2780,12 +2800,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0133f6cfd81cdc16e716de2982e012c62e6b9d4f12e41967b3ee361051c622aa"
+checksum = "2852b61c90fa8ce3c8fcc2aba76e6cefc20d648f9df29157d6b3a916278ef3e3"
 dependencies = [
  "asynchronous-codec 0.6.0",
- "bytes 1.1.0",
+ "bytes",
  "futures 0.3.18",
  "futures-timer",
  "libp2p-core",
@@ -2802,19 +2822,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-request-response"
-version = "0.12.0"
+name = "libp2p-rendezvous"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06cdae44b6821466123af93cbcdec7c9e6ba9534a8af9cdc296446d39416d241"
+checksum = "14a6d2b9e7677eff61dc3d2854876aaf3976d84a01ef6664b610c77a0c9407c5"
 dependencies = [
- "async-trait",
- "bytes 1.1.0",
+ "asynchronous-codec 0.6.0",
+ "bimap",
  "futures 0.3.18",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "lru",
- "minicbor",
+ "prost",
+ "prost-build",
+ "rand 0.8.4",
+ "sha2 0.9.8",
+ "thiserror",
+ "unsigned-varint 0.7.1",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-request-response"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a877a4ced6d46bf84677e1974e8cf61fb434af73b2e96fb48d6cb6223a4634d8"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures 0.3.18",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log",
+ "lru 0.7.7",
  "rand 0.7.3",
  "smallvec",
  "unsigned-varint 0.7.1",
@@ -2823,9 +2864,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7083861341e1555467863b4cd802bea1e8c4787c0f7b5110097d0f1f3248f9a9"
+checksum = "3f5184a508f223bc100a12665517773fb8730e9f36fc09eefb670bf01b107ae9"
 dependencies = [
  "either",
  "futures 0.3.18",
@@ -2839,9 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8cb308d4fc854869f5abb54fdab0833d2cf670d407c745849dc47e6e08d79c"
+checksum = "072c290f727d39bdc4e9d6d1c847978693d25a673bd757813681e33e5f6c00c2"
 dependencies = [
  "quote",
  "syn",
@@ -2849,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79edd26b6b4bb5feee210dcda562dca186940dfecb0024b979c3f50824b3bf28"
+checksum = "7399c5b6361ef525d41c11fcf51635724f832baf5819b30d3d873eabb4fbae4b"
 dependencies = [
  "async-io",
  "futures 0.3.18",
@@ -2866,9 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-uds"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280e793440dd4e9f273d714f4497325c72cddb0fe85a49f9a03c88f41dd20182"
+checksum = "b8b7563e46218165dfd60f64b96f7ce84590d75f53ecbdc74a7dd01450dc5973"
 dependencies = [
  "async-std",
  "futures 0.3.18",
@@ -2878,9 +2919,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f553b7140fad3d7a76f50497b0ea591e26737d9607428a75509fc191e4d1b1f6"
+checksum = "1008a302b73c5020251f9708c653f5ed08368e530e247cc9cd2f109ff30042cf"
 dependencies = [
  "futures 0.3.18",
  "js-sys",
@@ -2892,9 +2933,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf99dcbf5063e9d59087f61b1e85c686ceab2f5abedb472d32288065c0e5e27"
+checksum = "22e12df82d1ed64969371a9e65ea92b91064658604cc2576c2757f18ead9a1cf"
 dependencies = [
  "either",
  "futures 0.3.18",
@@ -2903,16 +2944,16 @@ dependencies = [
  "log",
  "quicksink",
  "rw-stream-sink",
- "soketto 0.4.2",
+ "soketto",
  "url 2.2.2",
  "webpki-roots 0.21.1",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214cc0dd9c37cbed27f0bb1eba0c41bbafdb93a8be5e9d6ae1e6b4b42cd044bf"
+checksum = "4e7362abb8867d7187e7e93df17f460d554c997fc5c8ac57dc1259057f6889af"
 dependencies = [
  "futures 0.3.18",
  "libp2p-core",
@@ -2923,37 +2964,18 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
+checksum = "b0452aac8bab02242429380e9b2f94ea20cea2b37e2c1777a1358799bbe97f37"
 dependencies = [
  "arrayref",
- "base64 0.12.3",
+ "base64",
  "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.8",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
-dependencies = [
- "arrayref",
- "base64 0.12.3",
- "digest 0.9.0",
- "hmac-drbg",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.7.3",
+ "rand 0.8.4",
  "serde",
  "sha2 0.9.8",
  "typenum",
@@ -2961,9 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1-core"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
 dependencies = [
  "crunchy",
  "digest 0.9.0",
@@ -2972,18 +2994,18 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1-gen-ecmult"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
 dependencies = [
  "libsecp256k1-core",
 ]
 
 [[package]]
 name = "libsecp256k1-gen-genmult"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
 dependencies = [
  "libsecp256k1-core",
 ]
@@ -3054,6 +3076,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c84e6fe5655adc6ce00787cf7dcaf8dc4f998a0565d23eafc207a8b08ca3349a"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3097,6 +3128,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memmap2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5172b50c23043ff43dd53e51392f36519d9b35a8f3a410d30ece5d1aedd58ae"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -3158,26 +3198,6 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "minicbor"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51aa5bb0ca22415daca596a227b507f880ad1b2318a87fa9325312a5d285ca0d"
-dependencies = [
- "minicbor-derive",
-]
-
-[[package]]
-name = "minicbor-derive"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54999f917cd092b13904737e26631aa2b2b88d625db68e4bab461dcd8006c788"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -3296,7 +3316,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56a336acba8bc87c8876f6425407dbbe6c417bf478b22015f8fb0994ef3bc0ab"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures 0.3.18",
  "log",
  "pin-project 1.0.8",
@@ -3455,6 +3475,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "open-metrics-client"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7337d80c23c2d8b1349563981bc4fb531220733743ba8115454a67b181173f0d"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "open-metrics-client-derive-text-encode",
+ "owning_ref",
+]
+
+[[package]]
+name = "open-metrics-client-derive-text-encode"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c83b586f00268c619c1cb3340ec1a6f59dd9ba1d9833a273a68e6d5cd8ffc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3474,9 +3517,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "owning_ref"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3599,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3616,7 +3668,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3633,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -3703,7 +3755,7 @@ dependencies = [
  "ethereum-types",
  "hashbrown",
  "impl-trait-for-tuples",
- "lru",
+ "lru 0.6.6",
  "parity-util-mem-derive",
  "parking_lot",
  "primitive-types",
@@ -3806,9 +3858,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -3994,9 +4046,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
+checksum = "b7f64969ffd5dd8f39bd57a68ac53c163a095ed9d0fb707146da1b27025a3504"
 dependencies = [
  "cfg-if 1.0.0",
  "fnv",
@@ -4008,37 +4060,39 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "heck",
  "itertools",
+ "lazy_static",
  "log",
  "multimap",
  "petgraph",
  "prost",
  "prost-types",
+ "regex",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
  "itertools",
@@ -4049,11 +4103,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "prost",
 ]
 
@@ -4629,7 +4683,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "rustc-hex",
 ]
 
@@ -4684,7 +4738,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "log",
  "ring",
  "sct 0.6.1",
@@ -4721,7 +4775,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
 dependencies = [
- "base64 0.13.0",
+ "base64",
 ]
 
 [[package]]
@@ -4743,17 +4797,17 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "salsa20"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
+checksum = "0c0fbb5f676da676c260ba276a8f43a8dc67cf02d1438423aeb1c677a7212686"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "sc-allocator"
-version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+version = "4.1.0-dev"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "log",
  "sp-core",
@@ -4764,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -4780,9 +4834,10 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "impl-trait-for-tuples",
+ "memmap2",
  "parity-scale-codec",
  "sc-chain-spec-derive",
  "sc-network",
@@ -4796,7 +4851,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -4807,7 +4862,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "fnv",
  "futures 0.3.18",
@@ -4835,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "async-trait",
  "futures 0.3.18",
@@ -4859,10 +4914,10 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "lazy_static",
- "libsecp256k1 0.6.0",
+ "libsecp256k1",
  "log",
  "parity-scale-codec",
  "parking_lot",
@@ -4870,6 +4925,7 @@ dependencies = [
  "sc-executor-wasmi",
  "sp-api",
  "sp-core",
+ "sp-core-hashing-proc-macro",
  "sp-externalities",
  "sp-io",
  "sp-panic-handler",
@@ -4884,7 +4940,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "derive_more",
  "environmental",
@@ -4902,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -4918,13 +4974,13 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "async-std",
  "async-trait",
  "asynchronous-codec 0.5.0",
  "bitflags",
- "bytes 1.1.0",
+ "bytes",
  "cid",
  "derive_more",
  "either",
@@ -4938,7 +4994,7 @@ dependencies = [
  "linked-hash-map",
  "linked_hash_set",
  "log",
- "lru",
+ "lru 0.7.7",
  "parity-scale-codec",
  "parking_lot",
  "pin-project 1.0.8",
@@ -4969,7 +5025,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "futures 0.3.18",
  "libp2p",
@@ -4982,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "futures 0.3.18",
  "jsonrpc-core",
@@ -5007,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "chrono",
  "futures 0.3.18",
@@ -5025,7 +5081,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "derive_more",
  "futures 0.3.18",
@@ -5039,7 +5095,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "futures 0.3.18",
  "futures-timer",
@@ -5402,28 +5458,13 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c71ed3d54db0a699f4948e1bb3e45b450fa31fe602621dee6680361d569c88"
-dependencies = [
- "base64 0.12.3",
- "bytes 0.5.6",
- "flate2",
- "futures 0.3.18",
- "httparse",
- "log",
- "rand 0.7.3",
- "sha-1",
-]
-
-[[package]]
-name = "soketto"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
- "base64 0.13.0",
- "bytes 1.1.0",
+ "base64",
+ "bytes",
+ "flate2",
  "futures 0.3.18",
  "httparse",
  "log",
@@ -5434,7 +5475,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "hash-db",
  "log",
@@ -5451,7 +5492,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.1.0",
@@ -5463,7 +5504,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -5476,7 +5517,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -5491,7 +5532,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5503,11 +5544,11 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "futures 0.3.18",
  "log",
- "lru",
+ "lru 0.7.7",
  "parity-scale-codec",
  "parking_lot",
  "sp-api",
@@ -5521,7 +5562,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "async-trait",
  "futures 0.3.18",
@@ -5540,9 +5581,10 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "base58",
+ "bitflags",
  "blake2-rfc",
  "byteorder",
  "dyn-clonable",
@@ -5553,7 +5595,7 @@ dependencies = [
  "hex",
  "impl-serde",
  "lazy_static",
- "libsecp256k1 0.6.0",
+ "libsecp256k1",
  "log",
  "merlin",
  "num-traits",
@@ -5568,6 +5610,7 @@ dependencies = [
  "secrecy",
  "serde",
  "sha2 0.9.8",
+ "sp-core-hashing",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -5584,9 +5627,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-core-hashing"
+version = "4.0.0-dev"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
+dependencies = [
+ "blake2-rfc",
+ "byteorder",
+ "sha2 0.9.8",
+ "sp-std",
+ "tiny-keccak",
+ "twox-hash",
+]
+
+[[package]]
+name = "sp-core-hashing-proc-macro"
+version = "4.0.0-dev"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sp-core-hashing",
+ "syn",
+]
+
+[[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "kvdb",
  "parking_lot",
@@ -5594,8 +5661,8 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "3.0.0"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+version = "4.0.0-dev"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5605,7 +5672,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -5616,7 +5683,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -5634,7 +5701,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -5648,11 +5715,11 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "futures 0.3.18",
  "hash-db",
- "libsecp256k1 0.6.0",
+ "libsecp256k1",
  "log",
  "parity-scale-codec",
  "parking_lot",
@@ -5672,7 +5739,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5687,24 +5754,26 @@ dependencies = [
 
 [[package]]
 name = "sp-maybe-compressed-blob"
-version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+version = "4.1.0-dev"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "sp-panic-handler"
-version = "3.0.0"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+version = "4.0.0-dev"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "backtrace",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
 name = "sp-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -5714,7 +5783,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -5736,7 +5805,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5753,7 +5822,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.1.0",
@@ -5764,8 +5833,8 @@ dependencies = [
 
 [[package]]
 name = "sp-serializer"
-version = "3.0.0"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+version = "4.0.0-dev"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "serde",
  "serde_json",
@@ -5774,7 +5843,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -5785,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "hash-db",
  "log",
@@ -5808,12 +5877,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -5826,7 +5895,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "log",
  "sp-core",
@@ -5839,7 +5908,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -5855,7 +5924,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -5867,7 +5936,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -5882,7 +5951,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -5898,7 +5967,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -5909,7 +5978,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5936,6 +6005,12 @@ dependencies = [
  "serde_json",
  "unicode-xid",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "standback"
@@ -6029,8 +6104,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.9.0"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.3#1df7fe589a94caa33e8b9290dd474613bc170416"
+version = "0.10.0-dev"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.12.4#d29c5273ca45d8500df13276cb8c734e53255cdb"
 dependencies = [
  "async-std",
  "derive_more",
@@ -6280,7 +6355,7 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -6462,6 +6537,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "tt-call"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e66dcbec4290c69dd03c57e76c2469ea5c7ce109c6dd4351c13055cf71ea055"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6546,7 +6627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
 dependencies = [
  "asynchronous-codec 0.5.0",
- "bytes 1.1.0",
+ "bytes",
  "futures-io",
  "futures-util",
 ]
@@ -6558,7 +6639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 dependencies = [
  "asynchronous-codec 0.6.0",
- "bytes 1.1.0",
+ "bytes",
  "futures-io",
  "futures-util",
 ]


### PR DESCRIPTION
```sh
Enumerating objects: 5, done.
Counting objects: 100% (5/5), done.
Delta compression using up to 16 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 4.34 KiB | 2.17 MiB/s, done.
Total 3 (delta 2), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/darwinia-v0.12.4.
remote: error: You're not authorized to push to this branch. Visit https://docs.github.com/articles/about-protected-branches/ for more information.
To https://github.com/darwinia-network/darwinia-messages-substrate.git
 ! [remote rejected]   darwinia-v0.12.4 -> darwinia-v0.12.4 (protected branch hook declined)
```

Due to branches protecting rules, I raise a pr to do this.