### PR TITLE
Integrate `fee-market` to `FromThisChainMessageVerifier`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           - bp-pangoro
           - bp-rococo
           - bp-darwinia-core
+          - bridge-runtime-common
     steps:
       - uses: actions/checkout@v2
       - name: Check ${{ matrix.package }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,7 @@ dependencies = [
  "pallet-bridge-dispatch",
  "pallet-bridge-grandpa",
  "pallet-bridge-messages",
+ "pallet-fee-market",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",

--- a/bin/runtime-common/Cargo.toml
+++ b/bin/runtime-common/Cargo.toml
@@ -21,6 +21,7 @@ bp-runtime = { path = "../../primitives/runtime", default-features = false }
 pallet-bridge-dispatch = { path = "../../modules/dispatch", default-features = false }
 pallet-bridge-grandpa = { path = "../../modules/grandpa", default-features = false }
 pallet-bridge-messages = { path = "../../modules/messages", default-features = false }
+pallet-fee-market = { path = "../../modules/fee-market", default-features = false }
 
 # Substrate dependencies
 
@@ -49,6 +50,7 @@ std = [
 	"pallet-bridge-dispatch/std",
 	"pallet-bridge-grandpa/std",
 	"pallet-bridge-messages/std",
+	"pallet-fee-market/std",
 	"pallet-transaction-payment/std",
 	"scale-info/std",
 	"sp-api/std",

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -290,6 +290,7 @@ pub mod source {
 		type Error = &'static str;
 
 		#[allow(clippy::single_match)]
+		#[cfg(not(feature = "runtime-benchmarks"))]
 		fn verify_message(
 			submitter: &OriginOf<ThisChain<B>>,
 			delivery_and_dispatch_fee: &BalanceOf<ThisChain<B>>,
@@ -345,6 +346,17 @@ pub mod source {
 				return Err(NO_MARKET_FEE);
 			}
 
+			Ok(())
+		}
+
+		#[cfg(feature = "runtime-benchmarks")]
+		fn verify_message(
+			_submitter: &OriginOf<ThisChain<B>>,
+			_delivery_and_dispatch_fee: &BalanceOf<ThisChain<B>>,
+			_lane: &LaneId,
+			_lane_outbound_data: &OutboundLaneData,
+			_payload: &FromThisChainMessagePayload<B>,
+		) -> Result<(), Self::Error> {
 			Ok(())
 		}
 	}

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -26,10 +26,7 @@ use bp_messages::{
 	target_chain::{DispatchMessage, MessageDispatch, ProvedLaneMessages, ProvedMessages},
 	InboundLaneData, LaneId, Message, MessageData, MessageKey, MessageNonce, OutboundLaneData,
 };
-use bp_runtime::{
-	messages::{DispatchFeePayment, MessageDispatchResult},
-	ChainId, Size, StorageProofChecker,
-};
+use bp_runtime::{messages::MessageDispatchResult, ChainId, Size, StorageProofChecker};
 use codec::{Decode, DecodeLimit, Encode};
 use frame_support::{
 	traits::{Currency, ExistenceRequirement},
@@ -260,7 +257,7 @@ pub mod source {
 	///   dispatch origin;
 	/// - check that the sender has paid enough funds for both message delivery and dispatch.
 	#[derive(RuntimeDebug)]
-	pub struct FromThisChainMessageVerifier<B>(PhantomData<B>);
+	pub struct FromThisChainMessageVerifier<B, F, I>(PhantomData<(B, F, I)>);
 
 	/// The error message returned from LaneMessageVerifier when outbound lane is disabled.
 	pub const MESSAGE_REJECTED_BY_OUTBOUND_LANE: &str =
@@ -273,19 +270,22 @@ pub mod source {
 	/// The error message returned from LaneMessageVerifier when the message fee is too low.
 	pub const TOO_LOW_FEE: &str = "Provided fee is below minimal threshold required by the lane.";
 
-	impl<B>
+	impl<B, F, I>
 		LaneMessageVerifier<
 			OriginOf<ThisChain<B>>,
 			AccountIdOf<ThisChain<B>>,
 			FromThisChainMessagePayload<B>,
 			BalanceOf<ThisChain<B>>,
-		> for FromThisChainMessageVerifier<B>
+		> for FromThisChainMessageVerifier<B, F, I>
 	where
 		B: MessageBridge,
+		F: pallet_fee_market::Config<I>,
+		I: 'static,
 		// matches requirements from the `frame_system::Config::Origin`
 		OriginOf<ThisChain<B>>: Clone
 			+ Into<Result<frame_system::RawOrigin<AccountIdOf<ThisChain<B>>>, OriginOf<ThisChain<B>>>>,
 		AccountIdOf<ThisChain<B>>: PartialEq + Clone,
+		pallet_fee_market::BalanceOf<F, I>: From<BalanceOf<ThisChain<B>>>,
 	{
 		type Error = &'static str;
 
@@ -329,15 +329,20 @@ pub mod source {
 				// is valid, or not.
 			};
 
-			let minimal_fee_in_this_tokens = estimate_message_dispatch_and_delivery_fee::<B>(
-				payload,
-				B::RELAYER_FEE_PERCENT,
-				None,
-			)?;
+			// Do the delivery_and_dispatch_fee. We assume that the delivery and dispatch fee always
+			// greater than the fee market provided fee.
+			if let Some(market_fee) = pallet_fee_market::Pallet::<F, I>::market_fee() {
+				let message_fee: pallet_fee_market::BalanceOf<F, I> =
+					(*delivery_and_dispatch_fee).into();
 
-			// compare with actual fee paid
-			if *delivery_and_dispatch_fee < minimal_fee_in_this_tokens {
-				return Err(TOO_LOW_FEE);
+				// compare with actual fee paid
+				if message_fee < market_fee {
+					return Err(TOO_LOW_FEE);
+				}
+			} else {
+				const NO_MARKET_FEE: &str = "The fee market are not ready for accepting messages.";
+
+				return Err(NO_MARKET_FEE);
 			}
 
 			Ok(())
@@ -756,15 +761,14 @@ pub mod target {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use bp_runtime::messages::DispatchFeePayment;
 	use codec::{Decode, Encode};
 	use frame_support::weights::Weight;
 	use std::ops::RangeInclusive;
 
 	const DELIVERY_TRANSACTION_WEIGHT: Weight = 100;
-	const DELIVERY_CONFIRMATION_TRANSACTION_WEIGHT: Weight = 100;
 	const THIS_CHAIN_WEIGHT_TO_BALANCE_RATE: Weight = 2;
 	const BRIDGED_CHAIN_WEIGHT_TO_BALANCE_RATE: Weight = 4;
-	const BRIDGED_CHAIN_TO_THIS_CHAIN_BALANCE_RATE: u32 = 6;
 	const BRIDGED_CHAIN_MAX_EXTRINSIC_WEIGHT: Weight = 2048;
 	const BRIDGED_CHAIN_MAX_EXTRINSIC_SIZE: u32 = 1024;
 
@@ -1022,10 +1026,6 @@ mod tests {
 		}
 	}
 
-	fn test_lane_outbound_data() -> OutboundLaneData {
-		OutboundLaneData::default()
-	}
-
 	#[test]
 	fn message_from_bridged_chain_is_decoded() {
 		// the message is encoded on the bridged chain
@@ -1062,180 +1062,6 @@ mod tests {
 
 	const TEST_LANE_ID: &LaneId = b"test";
 	const MAXIMAL_PENDING_MESSAGES_AT_TEST_LANE: MessageNonce = 32;
-
-	fn regular_outbound_message_payload() -> source::FromThisChainMessagePayload<OnThisChainBridge>
-	{
-		source::FromThisChainMessagePayload::<OnThisChainBridge> {
-			spec_version: 1,
-			weight: 100,
-			origin: bp_message_dispatch::CallOrigin::SourceRoot,
-			dispatch_fee_payment: DispatchFeePayment::AtSourceChain,
-			call: vec![42],
-		}
-	}
-
-	#[test]
-	fn message_fee_is_checked_by_verifier() {
-		const EXPECTED_MINIMAL_FEE: u32 = 5500;
-
-		// payload of the This -> Bridged chain message
-		let payload = regular_outbound_message_payload();
-
-		// let's check if estimation matching hardcoded value
-		assert_eq!(
-			source::estimate_message_dispatch_and_delivery_fee::<OnThisChainBridge>(
-				&payload,
-				OnThisChainBridge::RELAYER_FEE_PERCENT,
-				None,
-			),
-			Ok(ThisChainBalance(EXPECTED_MINIMAL_FEE)),
-		);
-
-		// let's check if estimation is less than hardcoded, if dispatch is paid at target chain
-		let mut payload_with_pay_on_target = regular_outbound_message_payload();
-		payload_with_pay_on_target.dispatch_fee_payment = DispatchFeePayment::AtTargetChain;
-		let fee_at_source =
-			source::estimate_message_dispatch_and_delivery_fee::<OnThisChainBridge>(
-				&payload_with_pay_on_target,
-				OnThisChainBridge::RELAYER_FEE_PERCENT,
-				None,
-			)
-			.expect(
-				"estimate_message_dispatch_and_delivery_fee failed for pay-at-target-chain message",
-			);
-		assert!(
-			fee_at_source < EXPECTED_MINIMAL_FEE.into(),
-			"Computed fee {:?} without prepaid dispatch must be less than the fee with prepaid dispatch {}",
-			fee_at_source,
-			EXPECTED_MINIMAL_FEE,
-		);
-
-		// and now check that the verifier checks the fee
-		assert_eq!(
-			source::FromThisChainMessageVerifier::<OnThisChainBridge>::verify_message(
-				&ThisChainOrigin(Ok(frame_system::RawOrigin::Root)),
-				&ThisChainBalance(1),
-				TEST_LANE_ID,
-				&test_lane_outbound_data(),
-				&payload,
-			),
-			Err(source::TOO_LOW_FEE)
-		);
-		assert!(source::FromThisChainMessageVerifier::<OnThisChainBridge>::verify_message(
-			&ThisChainOrigin(Ok(frame_system::RawOrigin::Root)),
-			&ThisChainBalance(1_000_000),
-			TEST_LANE_ID,
-			&test_lane_outbound_data(),
-			&payload,
-		)
-		.is_ok(),);
-	}
-
-	#[test]
-	fn should_disallow_root_calls_from_regular_accounts() {
-		// payload of the This -> Bridged chain message
-		let payload = source::FromThisChainMessagePayload::<OnThisChainBridge> {
-			spec_version: 1,
-			weight: 100,
-			origin: bp_message_dispatch::CallOrigin::SourceRoot,
-			dispatch_fee_payment: DispatchFeePayment::AtSourceChain,
-			call: vec![42],
-		};
-
-		// and now check that the verifier checks the fee
-		assert_eq!(
-			source::FromThisChainMessageVerifier::<OnThisChainBridge>::verify_message(
-				&ThisChainOrigin(Ok(frame_system::RawOrigin::Signed(ThisChainAccountId(0)))),
-				&ThisChainBalance(1_000_000),
-				TEST_LANE_ID,
-				&test_lane_outbound_data(),
-				&payload,
-			),
-			Err(source::BAD_ORIGIN)
-		);
-		assert_eq!(
-			source::FromThisChainMessageVerifier::<OnThisChainBridge>::verify_message(
-				&ThisChainOrigin(Ok(frame_system::RawOrigin::None)),
-				&ThisChainBalance(1_000_000),
-				TEST_LANE_ID,
-				&test_lane_outbound_data(),
-				&payload,
-			),
-			Err(source::BAD_ORIGIN)
-		);
-		assert!(source::FromThisChainMessageVerifier::<OnThisChainBridge>::verify_message(
-			&ThisChainOrigin(Ok(frame_system::RawOrigin::Root)),
-			&ThisChainBalance(1_000_000),
-			TEST_LANE_ID,
-			&test_lane_outbound_data(),
-			&payload,
-		)
-		.is_ok(),);
-	}
-
-	#[test]
-	fn should_verify_source_and_target_origin_matching() {
-		// payload of the This -> Bridged chain message
-		let payload = source::FromThisChainMessagePayload::<OnThisChainBridge> {
-			spec_version: 1,
-			weight: 100,
-			origin: bp_message_dispatch::CallOrigin::SourceAccount(ThisChainAccountId(1)),
-			dispatch_fee_payment: DispatchFeePayment::AtSourceChain,
-			call: vec![42],
-		};
-
-		// and now check that the verifier checks the fee
-		assert_eq!(
-			source::FromThisChainMessageVerifier::<OnThisChainBridge>::verify_message(
-				&ThisChainOrigin(Ok(frame_system::RawOrigin::Signed(ThisChainAccountId(0)))),
-				&ThisChainBalance(1_000_000),
-				TEST_LANE_ID,
-				&test_lane_outbound_data(),
-				&payload,
-			),
-			Err(source::BAD_ORIGIN)
-		);
-		assert!(source::FromThisChainMessageVerifier::<OnThisChainBridge>::verify_message(
-			&ThisChainOrigin(Ok(frame_system::RawOrigin::Signed(ThisChainAccountId(1)))),
-			&ThisChainBalance(1_000_000),
-			TEST_LANE_ID,
-			&test_lane_outbound_data(),
-			&payload,
-		)
-		.is_ok(),);
-	}
-
-	#[test]
-	fn message_is_rejected_when_sent_using_disabled_lane() {
-		assert_eq!(
-			source::FromThisChainMessageVerifier::<OnThisChainBridge>::verify_message(
-				&ThisChainOrigin(Ok(frame_system::RawOrigin::Root)),
-				&ThisChainBalance(1_000_000),
-				b"dsbl",
-				&test_lane_outbound_data(),
-				&regular_outbound_message_payload(),
-			),
-			Err(source::MESSAGE_REJECTED_BY_OUTBOUND_LANE)
-		);
-	}
-
-	#[test]
-	fn message_is_rejected_when_there_are_too_many_pending_messages_at_outbound_lane() {
-		assert_eq!(
-			source::FromThisChainMessageVerifier::<OnThisChainBridge>::verify_message(
-				&ThisChainOrigin(Ok(frame_system::RawOrigin::Root)),
-				&ThisChainBalance(1_000_000),
-				TEST_LANE_ID,
-				&OutboundLaneData {
-					latest_received_nonce: 100,
-					latest_generated_nonce: 100 + MAXIMAL_PENDING_MESSAGES_AT_TEST_LANE + 1,
-					..Default::default()
-				},
-				&regular_outbound_message_payload(),
-			),
-			Err(source::TOO_MANY_PENDING_MESSAGES)
-		);
-	}
 
 	#[test]
 	fn verify_chain_message_rejects_message_with_too_small_declared_weight() {
@@ -1564,22 +1390,5 @@ mod tests {
 			),
 			100 + 50 * 10 + 777,
 		);
-	}
-
-	#[test]
-	fn conversion_rate_override_works() {
-		let payload = regular_outbound_message_payload();
-		let regular_fee = source::estimate_message_dispatch_and_delivery_fee::<OnThisChainBridge>(
-			&payload,
-			OnThisChainBridge::RELAYER_FEE_PERCENT,
-			None,
-		);
-		let overrided_fee = source::estimate_message_dispatch_and_delivery_fee::<OnThisChainBridge>(
-			&payload,
-			OnThisChainBridge::RELAYER_FEE_PERCENT,
-			Some(FixedU128::from_float((BRIDGED_CHAIN_TO_THIS_CHAIN_BALANCE_RATE * 2) as f64)),
-		);
-
-		assert!(regular_fee < overrided_fee);
 	}
 }

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -22,9 +22,11 @@
 
 use bp_message_dispatch::MessageDispatch as _;
 use bp_messages::{
+	source_chain::LaneMessageVerifier,
 	target_chain::{DispatchMessage, MessageDispatch, ProvedLaneMessages, ProvedMessages},
 	InboundLaneData, LaneId, Message, MessageData, MessageKey, MessageNonce, OutboundLaneData,
 };
+use bp_polkadot_core::parachains::{ParaHash, ParaHasher, ParaId};
 use bp_runtime::{messages::MessageDispatchResult, ChainId, Size, StorageProofChecker};
 use codec::{Decode, DecodeLimit, Encode};
 use frame_support::{

--- a/primitives/parachains/src/lib.rs
+++ b/primitives/parachains/src/lib.rs
@@ -18,14 +18,10 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use bp_polkadot_core::{
-	parachains::{ParaHash, ParaHead, ParaId},
-	BlockNumber as RelayBlockNumber,
-};
+use bp_polkadot_core::parachains::ParaId;
 // use bp_runtime::{StorageDoubleMapKeyProvider, StorageMapKeyProvider};
-use codec::{Decode, Encode};
-use frame_support::{Blake2_128Concat, RuntimeDebug, Twox64Concat};
-use scale_info::TypeInfo;
+use codec::Encode;
+use frame_support::Twox64Concat;
 use sp_core::storage::StorageKey;
 
 // /// Best known parachain head hash.


### PR DESCRIPTION
Because the current CI/CD process ignored the `bridge-runtime-common` crate and did not show this broken issue before.

Integrate the fee market logic into the message verifier, so this can be reused in the `darwinia-common` and `darwinia-parachain` side.

- https://github.com/darwinia-network/darwinia-common/blob/main/node/runtime/common/src/impls.rs#L119-L206
- https://github.com/darwinia-network/darwinia-parachain/blob/main/runtime/common/src/lib.rs#L120-L212

```sh
error[E0425]: cannot find function `estimate_message_dispatch_and_delivery_fee` in this scope
   --> bin/runtime-common/src/messages.rs:332:37
    |
332 |             let minimal_fee_in_this_tokens = estimate_message_dispatch_and_delivery_fee::<B>(
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope

warning: unused import: `DispatchFeePayment`
  --> bin/runtime-common/src/messages.rs:30:13
   |
30 |     messages::{DispatchFeePayment, MessageDispatchResult},
   |                ^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

For more information about this error, try `rustc --explain E0425`.
warning: `bridge-runtime-common` (lib) generated 1 warning
error: could not compile `bridge-runtime-common` due to previous error; 1 warning emitted
warning: build failed, waiting for other jobs to finish...

```