### PR TITLE
Clean dependency

### DIFF
--- a/modules/fee-market/Cargo.toml
+++ b/modules/fee-market/Cargo.toml
@@ -25,11 +25,11 @@ sp-std             = { git = "https://github.com/paritytech/substrate", branch =
 # darwinia-bridges-substrate
 bp-messages            = { default-features = false, path = "../../primitives/messages" }
 bp-runtime             = { default-features = false, path = "../../primitives/runtime" }
-pallet-bridge-messages = { default-features = false, path = "../messages" }
 
 [dev-dependencies]
-bitvec          = { version = "1" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master" }
+bitvec                 = { version = "1" }
+pallet-bridge-messages = { path = "../messages" }
+pallet-balances        = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [features]
 default = ["std"]
@@ -49,7 +49,6 @@ std = [
 	# darwinia-bridges-substrate
 	"bp-messages/std",
 	"bp-runtime/std",
-	"pallet-bridge-messages/std",
 ]
 
 runtime-benchmarks = ["frame-benchmarking"]

--- a/modules/fee-market/Cargo.toml
+++ b/modules/fee-market/Cargo.toml
@@ -28,8 +28,8 @@ bp-runtime             = { default-features = false, path = "../../primitives/ru
 
 [dev-dependencies]
 bitvec                 = { version = "1" }
-pallet-bridge-messages = { path = "../messages" }
 pallet-balances        = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-bridge-messages = { path = "../messages" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
`pallet-fee-market` shouldn't rely directly on the `pallet-bridge-messages`.