### PR TITLE
Integrate `ensure_bridge_integrity`

### DIFF
--- a/runtime-common/src/integrity.rs
+++ b/runtime-common/src/integrity.rs
@@ -119,10 +119,10 @@ macro_rules! assert_bridge_messages_pallet_types(
 			use pallet_bridge_messages::Config as MessagesConfig;
 			use static_assertions::assert_type_eq_all;
 
-			assert_type_eq_all!(<$r as MessagesConfig<$i>>::OutboundPayload, FromThisChainMessagePayload);
+			assert_type_eq_all!(<$r as MessagesConfig<$i>>::OutboundPayload, FromThisChainMessagePayload<$bridge>);
 			assert_type_eq_all!(<$r as MessagesConfig<$i>>::OutboundMessageFee, BalanceOf<ThisChain<$bridge>>);
 
-			assert_type_eq_all!(<$r as MessagesConfig<$i>>::InboundPayload, FromBridgedChainMessagePayload<CallOf<ThisChain<$bridge>>>);
+			assert_type_eq_all!(<$r as MessagesConfig<$i>>::InboundPayload, FromBridgedChainMessagePayload<$bridge>);
 			assert_type_eq_all!(<$r as MessagesConfig<$i>>::InboundMessageFee, BalanceOf<BridgedChain<$bridge>>);
 			assert_type_eq_all!(<$r as MessagesConfig<$i>>::InboundRelayer, AccountIdOf<BridgedChain<$bridge>>);
 

--- a/runtime-common/src/pallets.rs
+++ b/runtime-common/src/pallets.rs
@@ -28,15 +28,24 @@ pub const WITH_CRAB_MESSAGES_PALLET_NAME: &str = "BridgeCrabMessages";
 /// Name of the With-CrabParachain messages pallet instance that is deployed at bridged chains.
 pub const WITH_CRAB_PARACHAIN_MESSAGES_PALLET_NAME: &str = "BridgeCrabParachainMessages";
 
+/// Name of the With-Pangoro GRANDPA pallet instance that is deployed at bridged chains.
+pub const WITH_PANGORO_GRANDPA_PALLET_NAME: &str = "BridgePangoroGrandpa";
 /// Name of the With-Pangoro messages pallet instance that is deployed at bridged chains.
 pub const WITH_PANGORO_MESSAGES_PALLET_NAME: &str = "BridgePangoroMessages";
 
+/// Name of the With-Pangolin GRANDPA pallet instance that is deployed at bridged chains.
+pub const WITH_PANGOLIN_GRANDPA_PALLET_NAME: &str = "BridgePangolinGrandpa";
 /// Name of the With-Pangolin messages pallet instance that is deployed at bridged chains.
 pub const WITH_PANGOLIN_MESSAGES_PALLET_NAME: &str = "BridgePangolinMessages";
 
+/// Name of the With-PangolinParachain GRANDPA pallet instance that is deployed at bridged chains.
+pub const WITH_PANGOLIN_PARACHAIN_GRANDPA_PALLET_NAME: &str = "BridgeRococoGrandpa";
 /// Name of the With-PangolinParachain messages pallet instance that is deployed at bridged chains.
 pub const WITH_PANGOLIN_PARACHAIN_MESSAGES_PALLET_NAME: &str = "BridgePangolinParachainMessages";
 
+/// Name of the With-PangolinParachainAlpha GRANDPA pallet instance that is deployed at bridged
+/// chains.
+pub const WITH_PANGOLIN_PARACHAIN_ALPHA_GRANDPA_PALLET_NAME: &str = "BridgeMoonbaseRelayGrandpa";
 /// Name of the With-PangolinParachainAlpha messages pallet instance that is deployed at bridged
 /// chains.
 pub const WITH_PANGOLIN_PARACHAIN_ALPHA_MESSAGES_PALLET_NAME: &str =


### PR DESCRIPTION
See https://github.com/darwinia-network/darwinia-common/pull/1469/commits/b856f97a70fef67bd5a5c4258beda5b20222192a

`FromThisChainMessagePayload` and  `FromBridgedChainMessagePayload` are different from ours now. So I need to tweak the test script to make it works.