### PR TITLE
Bump toolchain version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel    = "nightly-2022-07-24"
+channel    = "nightly-2022-11-15"
 components = ["cargo", "clippy", "rustc", "rustfmt", "rust-src"]
 profile    = "minimal"
 targets    = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Use the same version as darwinia 2.0 repo.