### PR TITLE
Propogate the message verification errors

### DIFF
--- a/modules/fee-market/src/tests.rs
+++ b/modules/fee-market/src/tests.rs
@@ -1065,7 +1065,7 @@ fn test_order_create_if_market_not_ready() {
 				),
 				DispatchError::Module(ModuleError {
 					index: 4,
-					error: [3, 0, 0, 0],
+					error: [3, 11, 0, 0],
 					message: Some("MessageRejectedByLaneVerifier")
 				})
 			);

--- a/modules/messages/Cargo.toml
+++ b/modules/messages/Cargo.toml
@@ -29,10 +29,10 @@ sp-std             = { workspace = true }
 
 [dev-dependencies]
 # darwinia-network
-bp-test-utils = { workspace = true }
+bp-test-utils = { workspace = true, features = ["std"] }
 # paritytech
 pallet-balances = { workspace = true, features = ["std"] }
-sp-io           = { workspace = true }
+sp-io           = { workspace = true, features = ["std"] }
 
 [features]
 default = ["std"]

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -31,7 +31,7 @@ use scale_info::TypeInfo;
 // darwinia-network
 use bp_runtime::{BasicOperatingMode, OperatingMode};
 // paritytech
-use frame_support::RuntimeDebug;
+use frame_support::{PalletError, RuntimeDebug};
 use sp_std::{collections::vec_deque::VecDeque, prelude::*};
 
 // Weight is reexported to avoid additional frame-support dependencies in related crates.
@@ -363,6 +363,35 @@ pub fn total_unrewarded_messages<RelayerId>(
 		},
 		_ => Some(0),
 	}
+}
+
+/// Error that happens during message verification.
+#[derive(Encode, Decode, RuntimeDebug, PartialEq, Eq, PalletError, TypeInfo)]
+pub enum VerificationError {
+	/// Rejected by the lane which is not open.
+	MessageRejectedByOutBoundLane,
+	/// The message origin is incorrect.
+	MessageDispatchWithBadOrigin,
+	/// The message fee is too low.
+	MessageWithTooLowFee,
+	/// Too many pending messages now.
+	TooManyPendingMessages,
+	/// The message proof is empty.
+	EmptyMessageProof,
+	/// The declared message weight is incorrect.
+	InvalidMessageWeight,
+	/// Declared messages count doesn't match actual value.
+	MessagesCountMismatch,
+	/// Can not find the message in the storage by the key.
+	MissingRequiredMessage,
+	/// Error returned while reading/decoding message data from the storage proof.
+	FailedToDecodeMessage,
+	/// The message is too large.
+	MessageTooLarge,
+	/// Error returned while reading/decoding outbound lane data from the storage proof.
+	FailedToDecodeOutboundLaneData,
+	/// Custom error
+	Other(#[codec(skip)] &'static str),
 }
 
 #[cfg(test)]

--- a/primitives/runtime/src/storage_proof.rs
+++ b/primitives/runtime/src/storage_proof.rs
@@ -45,8 +45,11 @@ pub enum ProofSize {
 
 #[derive(Eq, PartialEq, RuntimeDebug)]
 pub enum Error {
+	/// Expected storage root is missing from the proof.
 	StorageRootMismatch,
+	/// Unable to reach expected storage value using provided trie nodes.
 	StorageValueUnavailable,
+	/// Failed to decode storage value.
 	StorageValueDecodeFailed(codec::Error),
 }
 


### PR DESCRIPTION
Expand the current `MessageRejectedByChainVerifier` and `MessageRejectedByLaneVerifier` error types with `VerificationError` to expose the eaten static str errors.

Polkadot Apps issue: https://github.com/polkadot-js/apps/issues/9458

Have discussed this with the subscan team, they will support to parse the wrapped error later. 

